### PR TITLE
make category model and feature to show category list page

### DIFF
--- a/app/assets/stylesheets/blocks/_category-item.scss
+++ b/app/assets/stylesheets/blocks/_category-item.scss
@@ -1,0 +1,14 @@
+/* 一つのCategoryを表示するブロック */
+.category-item{
+  box-shadow: 0 0 4px gray;
+  margin: 15px; /*Blockにmarginを設定することになるのでよくない？*/
+  padding: 10px;
+
+  &__name{
+    margin-block: 0;
+  }
+
+  &__slug{
+    margin-block: 0;
+  }
+}

--- a/app/assets/stylesheets/blocks/_category-item.scss
+++ b/app/assets/stylesheets/blocks/_category-item.scss
@@ -1,8 +1,16 @@
+// 色を表す変数を定義
+// HTMLから値を代入できるように
+:root{
+  --color: rgb(0, 0, 0);
+}
+
 /* 一つのCategoryを表示するブロック */
 .category-item{
   box-shadow: 0 0 4px gray;
   margin: 15px; /*Blockにmarginを設定することになるのでよくない？*/
   padding: 10px;
+  // 背景色をHTMLから送られてきた色に変更する
+  background-color: var(--color);
 
   &__name{
     margin-block: 0;

--- a/app/assets/stylesheets/blocks/_category-list.scss
+++ b/app/assets/stylesheets/blocks/_category-list.scss
@@ -1,0 +1,3 @@
+// Categoryをリスト表示するブロック
+.category-list{
+}

--- a/app/assets/stylesheets/blocks/_link-list.scss
+++ b/app/assets/stylesheets/blocks/_link-list.scss
@@ -1,7 +1,14 @@
+%text-link-black{
+  color: black;
+  text-decoration: none;
+}
+
 // リンクをリスト表示するブロック
 .link-list{
+  &__category-list{
+    @extend %text-link-black
+  }
   &__todo-list{
-    color: black;
-    text-decoration: none;
+    @extend %text-link-black
   }
 }

--- a/app/assets/stylesheets/page/category/category-list.scss
+++ b/app/assets/stylesheets/page/category/category-list.scss
@@ -1,0 +1,4 @@
+@import "../main.scss";
+
+@import "../../blocks/_category-item.scss";
+@import "../../blocks/_category-list.scss";

--- a/app/controllers/CategoryController.scala
+++ b/app/controllers/CategoryController.scala
@@ -1,0 +1,55 @@
+package controllers
+
+import lib.model.Category
+import lib.persistence.onMySQL.CategoryRepository
+import model.view.viewvalues.{ViewValueHome, ViewValueCategoryList}
+import play.api.Logger
+import play.api.i18n.I18nSupport
+import play.api.mvc.{BaseController, ControllerComponents}
+
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+
+class CategoryController @Inject()(val controllerComponents: ControllerComponents)(implicit ec: ExecutionContext)
+  extends BaseController with I18nSupport {
+  val logger: Logger = Logger(this.getClass())
+
+  // to_do_categoryテーブルの操作をデバックするためのメソッド　
+  // テーブル操作の結果はlogに出力する
+  def debug() = Action async { implicit req =>
+    val vv = ViewValueHome(
+      title  = "Home",
+      cssSrc = Seq("home.css"),
+      jsSrc  = Seq("main.js")
+    )
+
+    val categoryWithNoId = Category("デザイナー", "design", Category.Color.RED)
+    for {
+      categoryId      <- CategoryRepository.add(categoryWithNoId)
+      categoryFromId  <- CategoryRepository.get(Category.Id(categoryId))
+      updatedCategory <- CategoryRepository.update(categoryFromId.get.map(_.copy(name = "updated")))
+      deletedCategory <- CategoryRepository.remove(updatedCategory.get.id)
+    } yield {
+      logger.debug("add: " + categoryId.toString)
+      logger.debug("get: " + categoryFromId.toString)
+      logger.debug("update: " + updatedCategory.toString)
+      logger.debug("delete: " + deletedCategory.toString)
+      Ok(views.html.Home(vv))
+    }
+  }
+
+  // to_do_categoryテーブルのレコード一覧を表示するメソッド
+  def list() = Action async { implicit req =>
+    for {
+      allCategory <- CategoryRepository.getAll()
+    } yield {
+      val vv = ViewValueCategoryList(
+        title       = "Category 一覧",
+        cssSrc      = Seq("category/category-list.css"),
+        jsSrc       = Seq("main.js"),
+        allCategory = allCategory,
+      )
+      Ok(views.html.category.List(vv))
+    }
+  }
+}

--- a/app/controllers/CategoryController.scala
+++ b/app/controllers/CategoryController.scala
@@ -44,7 +44,7 @@ class CategoryController @Inject()(val controllerComponents: ControllerComponent
       allCategory <- CategoryRepository.getAll()
     } yield {
       val vv = ViewValueCategoryList(
-        title       = "Category 一覧",
+        title       = "カテゴリ一覧",
         cssSrc      = Seq("category/category-list.css"),
         jsSrc       = Seq("main.js"),
         allCategory = allCategory,

--- a/app/lib/model/Category.scala
+++ b/app/lib/model/Category.scala
@@ -1,0 +1,53 @@
+package lib.model
+
+import ixias.model._
+import ixias.util.EnumStatus
+
+import java.time.LocalDateTime
+
+// Categoryを表すモデル
+//~~~~~~~~~~~~~~~~~~~~
+import Category._
+case class Category(
+  id:        Option[Id],
+  name:      String,
+  slug:      String,
+  color:     Color,
+  updatedAt: LocalDateTime = NOW,
+  createdAt: LocalDateTime = NOW
+) extends EntityModel[Id]
+
+// コンパニオンオブジェクト
+//~~~~~~~~~~~~~~~~~~~~~~~~
+object Category {
+  val Id  = the[Identity[Id]]
+  type Id = Long @@ Category
+  type WithNoId   = Entity.WithNoId[Id, Category]
+  type EmbeddedId = Entity.EmbeddedId[Id, Category]
+
+//  ステータス定義
+//  ~~~~~~~~~~~~~~~~~
+  sealed abstract class Color(val code: Short, val rgb: RGB) extends EnumStatus
+  object Color extends EnumStatus.Of[Color] {
+    case object RED     extends Color(code = 0, rgb = RGB(255, 0, 0))
+    case object GREEN   extends Color(code = 1, rgb = RGB(0, 255, 0))
+    case object BLUE    extends Color(code = 2, rgb = RGB(0, 0, 255))
+    case object YELLOW  extends Color(code = 3, rgb = RGB(255, 255, 0))
+    case object AQUA    extends Color(code = 4, rgb = RGB(0, 255, 255))
+    case object FUCHSIA extends Color(code = 5, rgb = RGB(255, 0, 255))
+  }
+
+  case class RGB(r: Int = 0, g: Int = 0, b: Int = 0)
+
+  // WithNoIdを作成するメソッド
+  def apply(name: String, slug: String, color: Color): WithNoId = {
+    new Entity.WithNoId(
+      new Category(
+        id    = None,
+        name  = name,
+        slug  = slug,
+        color = color,
+      )
+    )
+  }
+}

--- a/app/lib/persistence/Category.scala
+++ b/app/lib/persistence/Category.scala
@@ -1,0 +1,72 @@
+package lib.persistence
+
+import ixias.persistence.SlickRepository
+import lib.model.Category
+import slick.jdbc.JdbcProfile
+
+import scala.concurrent.Future
+
+// CategoryRepository: CategoryTableへのクエリ発行を行うRepository層の定義
+//~~~~~~~~~~~~~~~~~~~~~~
+case class CategoryRepository[P <: JdbcProfile]()(implicit val driver: P)
+  extends SlickRepository[Category.Id, Category, P]
+    with db.SlickResourceProvider[P] {
+
+  import api._
+
+  /**
+   * Get Category Data
+   */
+  def get(id: Id): Future[Option[EntityEmbeddedId]] =
+    RunDBAction(CategoryTable, "slave") {
+      _.filter(_.id === id).result.headOption
+    }
+
+  /**
+   * Get all Category Data
+   */
+  def getAll(): Future[Seq[EntityEmbeddedId]] =
+    RunDBAction(CategoryTable, "slave") {
+      _.result
+    }
+
+  /**
+   * Add Category Data
+   */
+  def add(entity: EntityWithNoId): Future[Id] =
+    RunDBAction(CategoryTable) { slick =>
+      (slick returning slick.map(_.id)) += entity.v
+    }
+
+  /**
+   * Update Category Data columns except id and created_at
+   */
+  def update(entity: EntityEmbeddedId): Future[Option[EntityEmbeddedId]] =
+    RunDBAction(CategoryTable) { slick =>
+      val row = slick.filter(_.id === entity.id)
+      for {
+        old <- row.result.headOption
+        _ <- old match {
+          case None    => DBIO.successful(0)
+          case Some(_) => row
+                          .map(p => (p.name, p.slug, p.color, p.updatedAt))
+                          .update(entity.v.name, entity.v.slug, entity.v.color, entity.v.updatedAt)
+        }
+      } yield old
+    }
+
+  /**
+   * Delete Category Data
+   */
+  def remove(id: Id): Future[Option[EntityEmbeddedId]] =
+    RunDBAction(CategoryTable) { slick =>
+      val row = slick.filter(_.id === id)
+      for {
+        old <- row.result.headOption
+        _   <- old match {
+          case None    => DBIO.successful(0)
+          case Some(_) => row.delete
+        }
+      } yield old
+    }
+}

--- a/app/lib/persistence/db/Category.scala
+++ b/app/lib/persistence/db/Category.scala
@@ -1,0 +1,61 @@
+package lib.persistence.db
+
+import ixias.persistence.model.Table
+import lib.model.Category
+import slick.jdbc.JdbcProfile
+
+import java.time.LocalDateTime
+
+// CategoryTable: Categoryテーブルへのマッピングを行う
+//~~~~~~~~~~~~~~
+case class CategoryTable[P <: JdbcProfile]()(implicit val driver: P)
+  extends Table[Category, P] {
+
+  import api._
+
+  // Definition of DataSourceName
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  lazy val dsn = Map(
+    "master" -> DataSourceName("ixias.db.mysql://master/to_do"),
+    "slave"  -> DataSourceName("ixias.db.mysql://slave/to_do")
+  )
+
+  // Definition of Query
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  class Query extends BasicQuery(new Table(_)) {}
+
+  lazy val query = new Query
+
+  // Definition of Table
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  class Table(tag: Tag) extends BasicTable(tag, "to_do_category") {
+
+    import Category._
+
+    // Columns
+    /* @1 */ def id        = column[Id]("id", O.UInt64, O.PrimaryKey, O.AutoInc)
+    /* @2 */ def name      = column[String]("name", O.Utf8Char255)
+    /* @3 */ def slug      = column[String]("slug", O.Utf8Char64)
+    /* @4 */ def color     = column[Color]("color", O.UInt8)
+    /* @5 */ def updatedAt = column[LocalDateTime]("updated_at", O.TsCurrent)
+    /* @6 */ def createdAt = column[LocalDateTime]("created_at", O.Ts)
+
+    type TableElementTuple = (
+      Option[Id], String, String, Color, LocalDateTime, LocalDateTime
+    )
+
+    // DB <=> Scala の相互のmapping定義
+    def * = (id.?, name, slug, color, updatedAt, createdAt) <> (
+      // Tuple(table) => Model
+      (t: TableElementTuple) => Category(
+        t._1, t._2, t._3, t._4, t._5, t._6
+      ),
+      // Model => Tuple(table)
+      (v: TableElementType) => Category.unapply(v).map { t =>
+        (
+          t._1, t._2, t._3, t._4, LocalDateTime.now(), t._6
+        )
+      }
+    )
+  }
+}

--- a/app/lib/persistence/db/SlickResourceProvider.scala
+++ b/app/lib/persistence/db/SlickResourceProvider.scala
@@ -12,11 +12,13 @@ import slick.jdbc.JdbcProfile
 trait SlickResourceProvider[P <: JdbcProfile] {
 
   implicit val driver: P
-  object UserTable extends UserTable
-  object TodoTable extends TodoTable
+  object UserTable     extends UserTable
+  object TodoTable     extends TodoTable
+  object CategoryTable extends CategoryTable
   // --[ テーブル定義 ] --------------------------------------
   lazy val AllTables = Seq(
     UserTable,
-    TodoTable
+    TodoTable,
+    CategoryTable,
   )
 }

--- a/app/lib/persistence/package.scala
+++ b/app/lib/persistence/package.scala
@@ -11,7 +11,8 @@ package object persistence {
   
   object onMySQL {
     implicit lazy val driver = slick.jdbc.MySQLProfile
-    object UserRepository extends UserRepository
-    object TodoRepository extends TodoRepository
+    object UserRepository     extends UserRepository
+    object TodoRepository     extends TodoRepository
+    object CategoryRepository extends CategoryRepository
   }
 }

--- a/app/model/view/viewvalues/category/ViewValueCategoryList.scala
+++ b/app/model/view/viewvalues/category/ViewValueCategoryList.scala
@@ -1,0 +1,11 @@
+package model.view.viewvalues
+
+import lib.model.Category
+
+// category/list(Category一覧)ページのviewvalue
+case class ViewValueCategoryList(
+  title:       String,
+  cssSrc:      Seq[String],
+  jsSrc:       Seq[String],
+  allCategory: Seq[Category.EmbeddedId],
+) extends ViewValueCommon

--- a/app/views/Home.scala.html
+++ b/app/views/Home.scala.html
@@ -9,7 +9,7 @@ Topページ
 @(vv: model.view.viewvalues.ViewValueCommon)
 @common.Default(vv){
   <ul class="link-list">
-    <li><a class="link-list__category-list" href="@routes.CategoryController.list()">カテゴリー一覧</a></li>
+    <li><a class="link-list__category-list" href="@routes.CategoryController.list()">カテゴリ一覧</a></li>
     <li><a class="link-list__todo-list" href="@routes.TodoController.list()">Todo一覧</a></li>
   </ul>
 }

--- a/app/views/Home.scala.html
+++ b/app/views/Home.scala.html
@@ -9,7 +9,7 @@ Topページ
 @(vv: model.view.viewvalues.ViewValueCommon)
 @common.Default(vv){
   <ul class="link-list">
-    <li><a class="link-list__category">カテゴリー一覧</a></li>
+    <li><a class="link-list__category-list" href="@routes.CategoryController.list()">カテゴリー一覧</a></li>
     <li><a class="link-list__todo-list" href="@routes.TodoController.list()">Todo一覧</a></li>
   </ul>
 }

--- a/app/views/category/List.scala.html
+++ b/app/views/category/List.scala.html
@@ -5,7 +5,8 @@ Category一覧を表示するページ
 @common.Default(vv){
 <div class="category-list">
   @for(category <- vv.allCategory) {
-  <div class="category-item">
+  @* scssの--color変数にrgb値を代入することで色を変更 *@
+  <div class="category-item" style="--color: rgb(@category.v.color.rgb.r, @category.v.color.rgb.g, @category.v.color.rgb.b);">
     <h2 class="category-item__name">@category.v.name</h2>
     <p class="category-item__slug">@category.v.slug</p>
   </div>

--- a/app/views/category/List.scala.html
+++ b/app/views/category/List.scala.html
@@ -1,0 +1,14 @@
+@*
+Category一覧を表示するページ
+*@
+@(vv: model.view.viewvalues.ViewValueCategoryList)
+@common.Default(vv){
+<div class="category-list">
+  @for(category <- vv.allCategory) {
+  <div class="category-item">
+    <h2 class="category-item__name">@category.v.name</h2>
+    <p class="category-item__slug">@category.v.slug</p>
+  </div>
+  }
+</div>
+}

--- a/app/views/todo/Edit.scala.html
+++ b/app/views/todo/Edit.scala.html
@@ -9,10 +9,10 @@ Todo更新画面
     @helper.form(action = routes.TodoController.update(vv.todoId)){
       @helper.CSRF.formField
       <div class="edit-form__category-input">
-        @* カテゴリーIdの入力欄(longNumber) *@
+        @* カテゴリIdの入力欄(longNumber) *@
         @helper.inputText(
           vv.form("categoryId"),
-          '_label -> "カテゴリーid", '_showConstraints -> false
+          '_label -> "カテゴリid", '_showConstraints -> false
         )
       </div>
       <div class="edit-form__title-input">

--- a/app/views/todo/Store.scala.html
+++ b/app/views/todo/Store.scala.html
@@ -9,10 +9,10 @@ Todo追加画面
     @helper.form(action = routes.TodoController.store){
       @helper.CSRF.formField
       <div class="store-form__category-input">
-        @* カテゴリーIdの入力欄(longNumber) *@
+        @* カテゴリIdの入力欄(longNumber) *@
         @helper.inputText(
           vv.form("categoryId"),
-          '_label -> "カテゴリーid", '_showConstraints -> false
+          '_label -> "カテゴリid", '_showConstraints -> false
         )
       </div>
       <div class="store-form__title-input">

--- a/conf/routes
+++ b/conf/routes
@@ -24,5 +24,11 @@ POST    /todo/edit/$todoId<[0-9]+>    controllers.TodoController.update(todoId: 
 # Todoの削除機能
 POST    /todo/delete/$todoId<[0-9]+>  controllers.TodoController.delete(todoId: Long)
 
+# Categoryのデバック画面
+GET    /category/debug                controllers.CategoryController.debug
+
+# Categoryの一覧表示画面
+GET     /category/list                controllers.CategoryController.list
+
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file                 controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
## 変更内容

- Categoryモデルの作成
- カテゴリデバックページの作成 [810f58e](https://github.com/yasu307/todo-app/pull/5/commits/810f58ec870d720baea4617f550b3c0eaf000fee)
- カテゴリ一覧ページの作成 [810f58e](https://github.com/yasu307/todo-app/pull/5/commits/810f58ec870d720baea4617f550b3c0eaf000fee)
- Home ->  カテゴリ一覧　リンクを作成　[2811fd6](https://github.com/yasu307/todo-app/pull/5/commits/2811fd6b137ed2b082ced0cd51dbefe160e9ce55)
- category-itemのbackground colorをカテゴリに設定されている色に変更するように　[2034357](https://github.com/yasu307/todo-app/pull/5/commits/20343577ada39f400b3d5c6adf9c5a579d5642e7)

## 画面変更
### カテゴリ一覧ページ(追加)
category/list
<img width="1792" alt="pull5 category:list" src="https://user-images.githubusercontent.com/29055153/169479166-b46740d1-15ae-4ce8-a874-0ad884255c8e.png">

## 懸念点
今回の実装ではCategory.ColorをEnumで定義しました。
要件には、今後カテゴリ追加をする際に色も選択可能にするよう書いてあります。この色の選択は、カラーコードの中からユーザーが好きな色を選択するのでしょうか？それとも、アプリ製作者側が挙げた色の中からユーザがどれかを選択するのでしょうか？私の理解では実行時Enumに値を追加するのは不可能なため、前者であれば実装不可能だと思っています。
todo-appのREADMEに書かれているMySQLの初期処理ではcolorレコードがTINYINTで設定されているため、Enum実装で問題ない。つまり後者で実装すべきということかなと思っています。

~~Colorのパラメーターの中にRGBというケースクラスを指定しました。意味的にRGBを一括りにしたいという意図がありこの設計にしましたが、今後FormとCategoryモデルのマッピングの記述にて、Colorの処理が複雑になり可読性が低くなる可能性があるかと思っています。~~
-> そんなことありませんでした。

category-itemの背景色を設定する処理についてです。これはHTMLにある値を装飾に反映させていますが、この方法を調べたところあまり記事を見つけらませんでした。現在はHTMLからCSSの変数に値を代入していますが、他に良い方法はあるでしょうか？