### PR TITLE
Create feature to add category

### DIFF
--- a/app/assets/stylesheets/blocks/_category-list.scss
+++ b/app/assets/stylesheets/blocks/_category-list.scss
@@ -1,3 +1,17 @@
 // Categoryをリスト表示するブロック
 .category-list{
+  // store-linkをcontents areaに含めるように
+  display: flow-root;
+
+  &__store-link{
+    // todo-listに粘着表示するように
+    position: sticky;
+    bottom: 40px;
+    right: 40px;
+
+    float: right;
+    margin: 40px;
+    color: black;
+    font-size: 50px;
+  }
 }

--- a/app/assets/stylesheets/blocks/_category-store-form.scss
+++ b/app/assets/stylesheets/blocks/_category-store-form.scss
@@ -1,0 +1,25 @@
+// 色を表す変数を定義
+// HTMLから値を代入できるように
+:root{
+  --color: rgb(0, 0, 0);
+}
+
+// カテゴリ追加フォームを表示するブロック
+.category-store-form{
+  &__color-dd{
+    // 子要素(color-btnとcolor-label)を中央揃えで表示
+    display: flex;
+    align-items: center;
+  }
+
+  // colorに対応する色の正方形を表示
+  &__color-label{
+    display: inline-block;
+    width: 1.5em;
+    height: 1.5em;
+    margin-right: 1em;
+    border: 0.05em solid;
+    // 背景色をHTMLから送られてきた色に変更する
+    background-color: var(--color);
+  }
+}

--- a/app/assets/stylesheets/page/category/category-store.scss
+++ b/app/assets/stylesheets/page/category/category-store.scss
@@ -1,0 +1,1 @@
+@import "../main.scss";

--- a/app/assets/stylesheets/page/category/category-store.scss
+++ b/app/assets/stylesheets/page/category/category-store.scss
@@ -1,1 +1,3 @@
 @import "../main.scss";
+
+@import "../../blocks/_category-store-form.scss";

--- a/app/controllers/CategoryController.scala
+++ b/app/controllers/CategoryController.scala
@@ -2,7 +2,6 @@ package controllers
 
 import lib.model.Category
 import lib.persistence.onMySQL.CategoryRepository
-import model.controller.options.CategoryColorOptions
 import model.form.formdata.CategoryFormData
 import model.view.viewvalues.{ViewValueCategoryList, ViewValueCategoryStore, ViewValueHome}
 import play.api.Logger
@@ -62,11 +61,11 @@ class CategoryController @Inject()(val controllerComponents: ControllerComponent
       // 処理が失敗した場合に呼び出される関数
       (formWithErrors: Form[CategoryFormData]) => {
         val vv = ViewValueCategoryStore(
-          title    = "カテゴリ追加画面",
-          cssSrc   = Seq("category/category-store.css"),
-          jsSrc    = Seq("main.js"),
-          form     = formWithErrors,
-          colorOpt = CategoryColorOptions.categoryColorOpt,
+          title       = "カテゴリ追加画面",
+          cssSrc      = Seq("category/category-store.css"),
+          jsSrc       = Seq("main.js"),
+          form        = formWithErrors,
+          colorValues = Category.Color.values,
         )
         Future.successful(BadRequest(views.html.category.Store(vv)))
       },
@@ -84,11 +83,11 @@ class CategoryController @Inject()(val controllerComponents: ControllerComponent
   // to_do_categoryレコードの追加内容を入力するformを表示するメソッド
   def register() = Action { implicit req =>
     val vv = ViewValueCategoryStore(
-      title    = "カテゴリ追加画面",
-      cssSrc   = Seq("category/category-store.css"),
-      jsSrc    = Seq("main.js"),
-      form     = CategoryFormData.form,
-      colorOpt = CategoryColorOptions.categoryColorOpt,
+      title       = "カテゴリ追加画面",
+      cssSrc      = Seq("category/category-store.css"),
+      jsSrc       = Seq("main.js"),
+      form        = CategoryFormData.form,
+      colorValues = Category.Color.values,
     )
     Ok(views.html.category.Store(vv))
   }

--- a/app/controllers/CategoryController.scala
+++ b/app/controllers/CategoryController.scala
@@ -2,13 +2,16 @@ package controllers
 
 import lib.model.Category
 import lib.persistence.onMySQL.CategoryRepository
-import model.view.viewvalues.{ViewValueHome, ViewValueCategoryList}
+import model.controller.options.CategoryColorOptions
+import model.form.formdata.CategoryFormData
+import model.view.viewvalues.{ViewValueCategoryList, ViewValueCategoryStore, ViewValueHome}
 import play.api.Logger
+import play.api.data.Form
 import play.api.i18n.I18nSupport
-import play.api.mvc.{BaseController, ControllerComponents}
+import play.api.mvc.{AnyContent, BaseController, ControllerComponents, Request}
 
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 class CategoryController @Inject()(val controllerComponents: ControllerComponents)(implicit ec: ExecutionContext)
   extends BaseController with I18nSupport {
@@ -51,5 +54,42 @@ class CategoryController @Inject()(val controllerComponents: ControllerComponent
       )
       Ok(views.html.category.List(vv))
     }
+  }
+
+  // to_do_categoryレコードを追加するメソッド
+  def store() = Action async { implicit request: Request[AnyContent] =>
+    CategoryFormData.form.bindFromRequest().fold(
+      // 処理が失敗した場合に呼び出される関数
+      (formWithErrors: Form[CategoryFormData]) => {
+        val vv = ViewValueCategoryStore(
+          title    = "カテゴリ追加画面",
+          cssSrc   = Seq("category/category-store.css"),
+          jsSrc    = Seq("main.js"),
+          form     = formWithErrors,
+          colorOpt = CategoryColorOptions.categoryColorOpt,
+        )
+        Future.successful(BadRequest(views.html.category.Store(vv)))
+      },
+      // 処理が成功した場合に呼び出される関数
+      (categoryFormData: CategoryFormData) => {
+        for {
+          _ <- CategoryRepository.add(Category(categoryFormData.name, categoryFormData.slug, categoryFormData.color))
+        } yield {
+          Redirect(routes.CategoryController.list)
+        }
+      }
+    )
+  }
+
+  // to_do_categoryレコードの追加内容を入力するformを表示するメソッド
+  def register() = Action { implicit req =>
+    val vv = ViewValueCategoryStore(
+      title    = "カテゴリ追加画面",
+      cssSrc   = Seq("category/category-store.css"),
+      jsSrc    = Seq("main.js"),
+      form     = CategoryFormData.form,
+      colorOpt = CategoryColorOptions.categoryColorOpt,
+    )
+    Ok(views.html.category.Store(vv))
   }
 }

--- a/app/model/controller/options/CategoryColorOptions.scala
+++ b/app/model/controller/options/CategoryColorOptions.scala
@@ -1,0 +1,8 @@
+package model.controller.options
+
+import lib.model.Category
+
+object CategoryColorOptions{
+  // フォームにて使用するCategory.Colorのラジオボタンフォームの選択肢一覧
+  final val categoryColorOpt: Seq[(String, String)] = Category.Color.values.map{state => (state.code.toString, state.toString)}
+}

--- a/app/model/controller/options/CategoryColorOptions.scala
+++ b/app/model/controller/options/CategoryColorOptions.scala
@@ -1,8 +1,0 @@
-package model.controller.options
-
-import lib.model.Category
-
-object CategoryColorOptions{
-  // フォームにて使用するCategory.Colorのラジオボタンフォームの選択肢一覧
-  final val categoryColorOpt: Seq[(String, String)] = Category.Color.values.map{state => (state.code.toString, state.toString)}
-}

--- a/app/model/form/formdata/CategoryFormData.scala
+++ b/app/model/form/formdata/CategoryFormData.scala
@@ -19,6 +19,7 @@ object CategoryFormData {
       "name"  -> nonEmptyText(maxLength = 255),
       // MySQLに英数字のみ許可する制約があるが、formでもチェックしないとエラー画面に移動してしまうので追加
       "slug"  -> nonEmptyText(maxLength = 64).verifying(Constraints.pattern("""[ -~]+""".r, error = "英数字で入力してください")),
+      // formでhelperを使っていないのでこのマッピングは使用されていない？
       "color" -> longNumber.transform[Category.Color](l => Category.Color(l.toShort), _.code),
     )(CategoryFormData.apply)(CategoryFormData.unapply)
   )

--- a/app/model/form/formdata/CategoryFormData.scala
+++ b/app/model/form/formdata/CategoryFormData.scala
@@ -1,0 +1,23 @@
+package model.form.formdata
+
+import lib.model.Category
+import play.api.data.Form
+import play.api.data.Forms._
+
+// カテゴリ追加画面のフォームで使用するデータ
+case class CategoryFormData(
+  name:  String,
+  slug:  String,
+  color: Category.Color,
+)
+
+object CategoryFormData {
+  // カテゴリ追加画面で使用するFormオブジェクト
+  val form = Form(
+    mapping(
+      "name"  -> nonEmptyText(maxLength = 255),
+      "slug"  -> nonEmptyText(maxLength = 64),
+      "color" -> longNumber.transform[Category.Color](l => Category.Color(l.toShort), _.code)
+    )(CategoryFormData.apply)(CategoryFormData.unapply)
+  )
+}

--- a/app/model/form/formdata/CategoryFormData.scala
+++ b/app/model/form/formdata/CategoryFormData.scala
@@ -3,6 +3,7 @@ package model.form.formdata
 import lib.model.Category
 import play.api.data.Form
 import play.api.data.Forms._
+import play.api.data.validation.Constraints
 
 // カテゴリ追加画面のフォームで使用するデータ
 case class CategoryFormData(
@@ -16,8 +17,9 @@ object CategoryFormData {
   val form = Form(
     mapping(
       "name"  -> nonEmptyText(maxLength = 255),
-      "slug"  -> nonEmptyText(maxLength = 64),
-      "color" -> longNumber.transform[Category.Color](l => Category.Color(l.toShort), _.code)
+      // MySQLに英数字のみ許可する制約があるが、formでもチェックしないとエラー画面に移動してしまうので追加
+      "slug"  -> nonEmptyText(maxLength = 64).verifying(Constraints.pattern("""[ -~]+""".r, error = "英数字で入力してください")),
+      "color" -> longNumber.transform[Category.Color](l => Category.Color(l.toShort), _.code),
     )(CategoryFormData.apply)(CategoryFormData.unapply)
   )
 }

--- a/app/model/view/viewvalues/category/ViewValueCategoryStore.scala
+++ b/app/model/view/viewvalues/category/ViewValueCategoryStore.scala
@@ -1,13 +1,14 @@
 package model.view.viewvalues
 
+import lib.model.Category
 import model.form.formdata.CategoryFormData
 import play.api.data.Form
 
 // category/store(カテゴリ追加フォーム)ページのviewvalue
 case class ViewValueCategoryStore(
-  title:    String,
-  cssSrc:   Seq[String],
-  jsSrc:    Seq[String],
-  form:     Form[CategoryFormData],
-  colorOpt: Seq[(String, String)],
+  title:       String,
+  cssSrc:      Seq[String],
+  jsSrc:       Seq[String],
+  form:        Form[CategoryFormData],
+  colorValues: List[Category.Color],
 ) extends ViewValueCommon

--- a/app/model/view/viewvalues/category/ViewValueCategoryStore.scala
+++ b/app/model/view/viewvalues/category/ViewValueCategoryStore.scala
@@ -1,0 +1,13 @@
+package model.view.viewvalues
+
+import model.form.formdata.CategoryFormData
+import play.api.data.Form
+
+// category/store(カテゴリ追加フォーム)ページのviewvalue
+case class ViewValueCategoryStore(
+  title:    String,
+  cssSrc:   Seq[String],
+  jsSrc:    Seq[String],
+  form:     Form[CategoryFormData],
+  colorOpt: Seq[(String, String)],
+) extends ViewValueCommon

--- a/app/views/category/List.scala.html
+++ b/app/views/category/List.scala.html
@@ -11,5 +11,9 @@ Category一覧を表示するページ
     <p class="category-item__slug">@category.v.slug</p>
   </div>
   }
+  @* カテゴリ追加画面へ遷移するボタン *@
+  <a class="category-list__store-link" href="@routes.CategoryController.store">
+    <i class="fas fa-plus-circle"></i>
+  </a>
 </div>
 }

--- a/app/views/category/Store.scala.html
+++ b/app/views/category/Store.scala.html
@@ -1,0 +1,37 @@
+@*
+Category追加画面
+*@
+@import model.view.viewvalues.ViewValueCategoryStore
+@(vv: ViewValueCategoryStore)(implicit messageProvider: MessagesProvider,  requestHeader: RequestHeader)
+@common.Default(vv){
+<div class="category-store-form">
+  @* 追加するCategoryの入力フォーム *@
+  @helper.form(action = routes.CategoryController.store){
+  @helper.CSRF.formField
+  <div class="category-store-form__name-input">
+    @* カテゴリ名の入力欄(NonEmptyText) *@
+    @helper.inputText(
+    vv.form("name"),
+    '_label -> "カテゴリ名", '_showConstraints -> false
+    )
+  </div>
+  <div class="category-store-form__slug-input">
+    @* slugの入力欄(NonEmptyText) *@
+    @helper.inputText(
+    vv.form("slug"),
+    'size -> 60,
+    '_label -> "slug", '_showConstraints -> false
+    )
+  </div>
+  <div class="category-store-form__color-select">
+    @* カテゴリの色のラジオボタン *@
+    @helper.inputRadioGroup(
+    vv.form("color"),
+    options = vv.colorOpt,
+    '_label -> "色", '_showConstraints -> false
+    )
+  </div>
+  <input class="category-store-form__submit-btn" type="submit" value="追加">
+  }
+</div>
+}

--- a/app/views/category/Store.scala.html
+++ b/app/views/category/Store.scala.html
@@ -12,6 +12,7 @@ Category追加画面
     @* カテゴリ名の入力欄(NonEmptyText) *@
     @helper.inputText(
     vv.form("name"),
+    'size -> 40,
     '_label -> "カテゴリ名", '_showConstraints -> false
     )
   </div>
@@ -19,7 +20,7 @@ Category追加画面
     @* slugの入力欄(NonEmptyText) *@
     @helper.inputText(
     vv.form("slug"),
-    'size -> 60,
+    'size -> 20,
     '_label -> "slug", '_showConstraints -> false
     )
   </div>

--- a/app/views/category/Store.scala.html
+++ b/app/views/category/Store.scala.html
@@ -24,13 +24,18 @@ Category追加画面
     '_label -> "slug", '_showConstraints -> false
     )
   </div>
-  <div class="category-store-form__color-select">
+  <div class="category-store-form__color-input">
     @* カテゴリの色のラジオボタン *@
-    @helper.inputRadioGroup(
-    vv.form("color"),
-    options = vv.colorOpt,
-    '_label -> "色", '_showConstraints -> false
-    )
+    <dl>
+      <dt>色</dt>
+      <dd class="category-store-form__color-dd">
+        @for(color <- vv.colorValues){
+          @* helperを使用していないので制約やエラーメッセージが機能していないが、checkedを指定することでどのボタンも選択されていない状態が発生しないようにした *@
+          <input type="radio" id="color_@color.code.toString" class="category-store-form__color-btn" name="color" value=@color.code.toString @if(color.code == 0){checked}>
+          <label for="color_@color.code.toString" class="category-store-form__color-label" style="--color: @color.rgb.toString"></label>
+        }
+      </dd>
+    </dl>
   </div>
   <input class="category-store-form__submit-btn" type="submit" value="追加">
   }

--- a/conf/routes
+++ b/conf/routes
@@ -30,5 +30,9 @@ GET    /category/debug                controllers.CategoryController.debug
 # Categoryの一覧表示画面
 GET     /category/list                controllers.CategoryController.list
 
+# Categoryの追加画面
+GET     /category/store               controllers.CategoryController.register
+POST    /category/store               controllers.CategoryController.store
+
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file                 controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
## 変更内容

- カテゴリ追加フォームの作成 [074889b](https://github.com/yasu307/todo-app/pull/6/commits/074889b59b39bf99f0d841bc75a9e2f7bbaf3b95)
- カテゴリ一覧ページからカテゴリ追加ページへのリンク機能を作成 [a6e28d9](https://github.com/yasu307/todo-app/pull/6/commits/a6e28d96f8e3451f87d3d492106cac329df0dbd8)
- slugのフォームに英数字以外を許可しない制約を作成 [90413ff](https://github.com/yasu307/todo-app/pull/6/commits/90413ff2e87f7c3f0f96691327eada4a59800f9b)
- 色選択フォームのラベルにCategory.Colorのrgbに対応した色の正方形を表示 [0af80a8](https://github.com/yasu307/todo-app/pull/6/commits/0af80a8dc64a103c0fc91aee0dbb22b85ecc7f8a)

## 画面変更
### カテゴリ一覧ページ(変更)
category/list
変更内容

- カテゴリ追加ページへ遷移するボタンを作成
<img width="1792" alt="pull6 category:list" src="https://user-images.githubusercontent.com/29055153/169794926-4c2ceeed-4fd2-4ab8-94fe-717fed2a20e3.png">

### カテゴリ追加ページ(追加)
category/store
<img width="1792" alt="pull6 category:store" src="https://user-images.githubusercontent.com/29055153/169794964-ead26543-95c1-4f86-a274-7b16ca32c5d2.png">