### PR TITLE
Create feature to get category data at todo pages

### DIFF
--- a/app/assets/stylesheets/blocks/_todo-form.scss
+++ b/app/assets/stylesheets/blocks/_todo-form.scss
@@ -1,0 +1,14 @@
+// 色を表す変数を定義
+// HTMLから値を代入できるように
+:root{
+  --color: rgb(0, 0, 0);
+}
+
+// todo入力フォームを表示するブロック
+// 現状ではtodo追加フォーム、todo更新フォームにて使用されている at 2022/05/26
+.todo-form{
+  &__category-label{
+    // 背景色をHTMLから送られてきた色に変更する
+    background-color: var(--color);
+  }
+}

--- a/app/assets/stylesheets/blocks/_todo-item.scss
+++ b/app/assets/stylesheets/blocks/_todo-item.scss
@@ -1,5 +1,20 @@
 @import "../placeholders/_font-awesome-link.scss";
 
+// 色を表す変数を定義
+// HTMLから値を代入できるように
+:root{
+  --color: rgb(0, 0, 0);
+}
+
+%sub-info-item{
+  border: solid;
+  border-radius: 10px;
+  padding: 0.5em;
+  margin: 0.5em 0.5em 0.5em 0;
+  font-weight: bold;
+  font-size: 0.5em;
+}
+
 /* 一つのtodoを表示するブロック */
 .todo-item{
   box-shadow: 0 0 4px gray;
@@ -14,12 +29,14 @@
     display: flex;
   }
 
-  &__category, &__status{
-    border: solid;
-    border-radius: 10px;
-    padding: 0.5em;
-    margin: 0.5em 0.5em 0.5em 0;
-    font-size: 0.5em;
+  &__category{
+    @extend %sub-info-item;
+    // 背景色をHTMLから送られてきた色に変更する
+    background-color: var(--color);
+  }
+
+  &__status{
+    @extend %sub-info-item;
   }
 
   &__body{

--- a/app/assets/stylesheets/page/main.scss
+++ b/app/assets/stylesheets/page/main.scss
@@ -22,6 +22,7 @@ body {
     line-height:       70px;
     font-size:         20px;
     font-weight:       bold;
+    text-decoration:   none;
   }
 }
 

--- a/app/assets/stylesheets/page/todo/todo-edit.scss
+++ b/app/assets/stylesheets/page/todo/todo-edit.scss
@@ -1,1 +1,3 @@
 @import "../main.scss";
+
+@import "../../blocks/_todo-form.scss";

--- a/app/assets/stylesheets/page/todo/todo-store.scss
+++ b/app/assets/stylesheets/page/todo/todo-store.scss
@@ -1,1 +1,3 @@
 @import "../main.scss";
+
+@import "../../blocks/_todo-form.scss";

--- a/app/controllers/TodoController.scala
+++ b/app/controllers/TodoController.scala
@@ -43,10 +43,9 @@ class TodoController @Inject()(val controllerComponents: ControllerComponents)(i
 
   // to_doテーブルのレコード一覧を表示するメソッド
   def list() = Action async{ implicit req =>
-    for{
-      allTodo     <- TodoRepository.getAll()
-      allCategory <- CategoryRepository.getAll()
-    }yield{
+    for {
+      (allTodo, allCategory) <- TodoRepository.getAll() zip CategoryRepository.getAll()
+    } yield {
       val vv = ViewValueTodoList(
         title       = "Todo 一覧",
         cssSrc      = Seq("todo/todo-list.css"),
@@ -106,9 +105,8 @@ class TodoController @Inject()(val controllerComponents: ControllerComponents)(i
   // to_doの内容を編集する画面を表示するメソッド
   // todoをそのままeditの引数にしなかった理由 -> routes参照
   def edit(todoId: Long) = Action async { implicit req =>
-    for{
-      todoOpt     <- TodoRepository.get(Todo.Id(todoId))
-      allCategory <- CategoryRepository.getAll()
+    for {
+      (todoOpt, allCategory) <- TodoRepository.get(Todo.Id(todoId)) zip CategoryRepository.getAll()
     }yield{
       todoOpt match {
         // todoIdに対応するtodoレコードがあればそのtodoを更新する画面に遷移する

--- a/app/lib/model/Category.scala
+++ b/app/lib/model/Category.scala
@@ -29,12 +29,12 @@ object Category {
 //  ~~~~~~~~~~~~~~~~~
   sealed abstract class Color(val code: Short, val rgb: RGB) extends EnumStatus
   object Color extends EnumStatus.Of[Color] {
-    case object RED     extends Color(code = 0, rgb = RGB(255, 0, 0))
-    case object GREEN   extends Color(code = 1, rgb = RGB(0, 255, 0))
-    case object BLUE    extends Color(code = 2, rgb = RGB(0, 0, 255))
-    case object YELLOW  extends Color(code = 3, rgb = RGB(255, 255, 0))
-    case object AQUA    extends Color(code = 4, rgb = RGB(0, 255, 255))
-    case object FUCHSIA extends Color(code = 5, rgb = RGB(255, 0, 255))
+    case object RED     extends Color(code = 0, rgb = RGB(255, 51, 51))
+    case object GREEN   extends Color(code = 1, rgb = RGB(51, 255, 51))
+    case object BLUE    extends Color(code = 2, rgb = RGB(51, 102, 255))
+    case object YELLOW  extends Color(code = 3, rgb = RGB(255, 255, 102))
+    case object AQUA    extends Color(code = 4, rgb = RGB(102, 255, 255))
+    case object FUCHSIA extends Color(code = 5, rgb = RGB(255, 102, 255))
   }
 
   case class RGB(r: Int = 0, g: Int = 0, b: Int = 0)

--- a/app/lib/model/Category.scala
+++ b/app/lib/model/Category.scala
@@ -42,7 +42,7 @@ object Category {
   // 前は存在していたが現在は削除されたカテゴリのidを表す変数
   // todoが"どのカテゴリにも紐づいていない"ことを表すために用いる
   // to_doテーブルの設定によりnullや0以下の値は設定できないため、一番使用される可能性が低いLong.MaxValueを用いる
-  final val deletedCategoryId = Category.Id(Long.MaxValue)
+  final val deletedId = Category.Id(Long.MaxValue)
 
   // WithNoIdを作成するメソッド
   def apply(name: String, slug: String, color: Category.Color): WithNoId = {

--- a/app/lib/model/Category.scala
+++ b/app/lib/model/Category.scala
@@ -42,7 +42,7 @@ object Category {
   // 前は存在していたが現在は削除されたカテゴリのidを表す変数
   // todoが"どのカテゴリにも紐づいていない"ことを表すために用いる
   // to_doテーブルの設定によりnullや0以下の値は設定できないため、一番使用される可能性が低いLong.MaxValueを用いる
-  final val deletedCategoryId = Long.MaxValue
+  final val deletedCategoryId = Category.Id(Long.MaxValue)
 
   // WithNoIdを作成するメソッド
   def apply(name: String, slug: String, color: Category.Color): WithNoId = {

--- a/app/lib/model/Todo.scala
+++ b/app/lib/model/Todo.scala
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
 import Todo._
 case class Todo(
   id:         Option[Id],
-  categoryId: Long, //todo TodoCategoryをインポートして型を指定する必要がある？
+  categoryId: Category.Id,
   title:      String,
   body:       String,
   state:      Status,
@@ -36,7 +36,7 @@ object Todo {
   }
 
   // INSERT時のIDがAutoincrementのため,IDなしであることを示すオブジェクトに変換
-  def apply(categoryId: Long, title: String, body: String): WithNoId = {
+  def apply(categoryId: Category.Id, title: String, body: String): WithNoId = {
     new Entity.WithNoId(
       new Todo(
         id         = None,
@@ -49,7 +49,7 @@ object Todo {
   }
 
   // EmbeddedIdを作成するメソッド
-  def apply(todoId: Todo.Id, categoryId: Long, title: String, body: String, state: Todo.Status): EmbeddedId = {
+  def apply(todoId: Todo.Id, categoryId: Category.Id, title: String, body: String, state: Todo.Status): EmbeddedId = {
     new Todo(
       id         = Some(todoId),
       categoryId = categoryId,

--- a/app/lib/persistence/Category.scala
+++ b/app/lib/persistence/Category.scala
@@ -80,7 +80,7 @@ case class CategoryRepository[P <: JdbcProfile]()(implicit val driver: P)
         // カテゴリを削除するクエリ
         val deleteCategory = categorySlick.filter(_.id === id).delete
         // 削除するカテゴリに紐づけられているtodoを更新するクエリ
-        val updateTodos    = todoSlick.filter(_.categoryId === id.toLong).map(_.categoryId).update(Category.deletedCategoryId)
+        val updateTodos    = todoSlick.filter(_.categoryId === id).map(_.categoryId).update(Category.deletedCategoryId)
         // 二つのクエリをトランザクション処理する
         db.run((deleteCategory andFinally updateTodos).transactionally)
       }(Predef.identity)

--- a/app/lib/persistence/Category.scala
+++ b/app/lib/persistence/Category.scala
@@ -80,7 +80,7 @@ case class CategoryRepository[P <: JdbcProfile]()(implicit val driver: P)
         // カテゴリを削除するクエリ
         val deleteCategory = categorySlick.filter(_.id === id).delete
         // 削除するカテゴリに紐づけられているtodoを更新するクエリ
-        val updateTodos    = todoSlick.filter(_.categoryId === id).map(_.categoryId).update(Category.deletedCategoryId)
+        val updateTodos    = todoSlick.filter(_.categoryId === id).map(_.categoryId).update(Category.deletedId)
         // 二つのクエリをトランザクション処理する
         db.run((deleteCategory andFinally updateTodos).transactionally)
       }(Predef.identity)

--- a/app/lib/persistence/Category.scala
+++ b/app/lib/persistence/Category.scala
@@ -49,8 +49,8 @@ case class CategoryRepository[P <: JdbcProfile]()(implicit val driver: P)
         _ <- old match {
           case None    => DBIO.successful(0)
           case Some(_) => row
-                          .map(p => (p.name, p.slug, p.color, p.updatedAt))
-                          .update(entity.v.name, entity.v.slug, entity.v.color, entity.v.updatedAt)
+                          .map(p => (p.name, p.slug, p.color))
+                          .update(entity.v.name, entity.v.slug, entity.v.color)
         }
       } yield old
     }

--- a/app/lib/persistence/Todo.scala
+++ b/app/lib/persistence/Todo.scala
@@ -50,8 +50,8 @@ case class TodoRepository[P <: JdbcProfile]()(implicit val driver: P)
         _   <- old match {
           case None    => DBIO.successful(0)
           case Some(_) => row
-                          .map(p => (p.categoryId, p.title, p.body, p.state, p.updatedAt))
-                          .update(entity.v.categoryId, entity.v.title, entity.v.body, entity.v.state, entity.v.updatedAt)
+                          .map(p => (p.categoryId, p.title, p.body, p.state))
+                          .update(entity.v.categoryId, entity.v.title, entity.v.body, entity.v.state)
         }
       } yield old
     }

--- a/app/lib/persistence/db/Todo.scala
+++ b/app/lib/persistence/db/Todo.scala
@@ -1,7 +1,7 @@
 package lib.persistence.db
 
 import ixias.persistence.model.Table
-import lib.model.Todo
+import lib.model.{Category, Todo}
 import slick.jdbc.JdbcProfile
 
 import java.time.LocalDateTime
@@ -30,7 +30,7 @@ case class TodoTable[P <: JdbcProfile]()(implicit val driver: P)
     import Todo._
     // Columns
     /* @1 */ def id         = column[Id]            ("id",          O.UInt64, O.PrimaryKey, O.AutoInc)
-    /* @2 */ def categoryId = column[Long]          ("category_id", O.UInt64)
+    /* @2 */ def categoryId = column[Category.Id]   ("category_id", O.UInt64)
     /* @3 */ def title      = column[String]        ("title",       O.Utf8Char255)
     /* @4 */ def body       = column[String]        ("body",        O.Text)
     /* @5 */ def state      = column[Status]        ("state",       O.UInt8)
@@ -38,7 +38,7 @@ case class TodoTable[P <: JdbcProfile]()(implicit val driver: P)
     /* @7 */ def createdAt  = column[LocalDateTime] ("created_at",  O.Ts)
 
     type TableElementTuple = (
-      Option[Id], Long, String, String, Status, LocalDateTime, LocalDateTime
+      Option[Id], Category.Id, String, String, Status, LocalDateTime, LocalDateTime
     )
 
     // DB <=> Scala の相互のmapping定義

--- a/app/model/form/formdata/TodoEditFormData.scala
+++ b/app/model/form/formdata/TodoEditFormData.scala
@@ -1,6 +1,6 @@
 package model.form.formdata
 
-import lib.model.Todo
+import lib.model.{Category, Todo}
 import play.api.data.Form
 import play.api.data.Forms._
 
@@ -10,7 +10,7 @@ import play.api.data.Forms._
 // Todoモデルのインスタンスを元にこのフォームデータを埋めた結果を取得するには
 // TodoEditFormData.form.fill(todo) とする。
 case class TodoEditFormData(
-  categoryId: Long, //todo TodoCategoryをインポートして型を指定する必要がある？
+  categoryId: Category.Id,
   title:      String,
   body:       String,
   state:      Todo.Status,
@@ -20,7 +20,7 @@ object TodoEditFormData {
   // Todo更新画面で使用するFormオブジェクト
   val form = Form(
     mapping(
-      "categoryId" -> longNumber(),
+      "categoryId" -> longNumber.transform[Category.Id](l => Category.Id(l), _.toLong),
       "title"      -> nonEmptyText(maxLength = 255),
       "body"       -> text(),
       "state"      -> longNumber.transform[Todo.Status](l => Todo.Status(l.toShort), _.code),

--- a/app/model/form/formdata/TodoFormData.scala
+++ b/app/model/form/formdata/TodoFormData.scala
@@ -1,11 +1,12 @@
 package model.form.formdata
 
+import lib.model.Category
 import play.api.data.Form
 import play.api.data.Forms._
 
 // Todo追加画面のフォームで使用するデータ
 case class TodoFormData(
-  categoryId: Long, //todo TodoCategoryをインポートして型を指定する必要がある？
+  categoryId: Category.Id,
   title:      String,
   body:       String
 )
@@ -14,7 +15,7 @@ object TodoFormData {
   // Todo追加画面で使用するFormオブジェクト
   val form = Form(
     mapping(
-      "categoryId" -> longNumber(),
+      "categoryId" -> longNumber.transform[Category.Id](l => Category.Id(l), _.toLong),
       "title"      -> nonEmptyText(maxLength = 255),
       "body"       -> text()
     )(TodoFormData.apply)(TodoFormData.unapply)

--- a/app/model/view/viewvalues/todo/ViewValueTodoEdit.scala
+++ b/app/model/view/viewvalues/todo/ViewValueTodoEdit.scala
@@ -1,14 +1,16 @@
 package model.view.viewvalues
 
+import lib.model.Category
 import model.form.formdata.TodoEditFormData
 import play.api.data.Form
 
 // todo/edit(Todo更新フォーム)ページのviewvalue
 case class ViewValueTodoEdit(
-  title:     String,
-  cssSrc:    Seq[String],
-  jsSrc:     Seq[String],
-  form:      Form[TodoEditFormData],
-  statusOpt: Seq[(String, String)],
-  todoId:    Long,
+  title:       String,
+  cssSrc:      Seq[String],
+  jsSrc:       Seq[String],
+  form:        Form[TodoEditFormData],
+  statusOpt:   Seq[(String, String)],
+  todoId:      Long,
+  allCategory: Seq[Category.EmbeddedId],
 ) extends ViewValueCommon

--- a/app/model/view/viewvalues/todo/ViewValueTodoList.scala
+++ b/app/model/view/viewvalues/todo/ViewValueTodoList.scala
@@ -1,11 +1,12 @@
 package model.view.viewvalues
 
-import lib.model.Todo
+import lib.model.{Category, Todo}
 
 // todo/list(Todo一覧)ページのviewvalue
 case class ViewValueTodoList(
-  title:   String,
-  cssSrc:  Seq[String],
-  jsSrc:   Seq[String],
-  allTodo: Seq[Todo.EmbeddedId],
+  title:       String,
+  cssSrc:      Seq[String],
+  jsSrc:       Seq[String],
+  allTodo:     Seq[Todo.EmbeddedId],
+  allCategory: Seq[Category.EmbeddedId],
 ) extends ViewValueCommon

--- a/app/model/view/viewvalues/todo/ViewValueTodoStore.scala
+++ b/app/model/view/viewvalues/todo/ViewValueTodoStore.scala
@@ -1,12 +1,14 @@
 package model.view.viewvalues
 
+import lib.model.Category
 import model.form.formdata.TodoFormData
 import play.api.data.Form
 
 // todo/store(Todo追加フォーム)ページのviewvalue
 case class ViewValueTodoStore(
-  title:   String,
-  cssSrc:  Seq[String],
-  jsSrc:   Seq[String],
-  form:    Form[TodoFormData],
+  title:       String,
+  cssSrc:      Seq[String],
+  jsSrc:       Seq[String],
+  form:        Form[TodoFormData],
+  allCategory: Seq[Category.EmbeddedId],
 ) extends ViewValueCommon

--- a/app/views/category/List.scala.html
+++ b/app/views/category/List.scala.html
@@ -6,7 +6,7 @@ Category一覧を表示するページ
 <div class="category-list">
   @for(category <- vv.allCategory) {
   @* scssの--color変数にrgb値を代入することで色を変更 *@
-  <div class="category-item" style="--color: rgb(@category.v.color.rgb.r, @category.v.color.rgb.g, @category.v.color.rgb.b);">
+  <div class="category-item" style="--color: @category.v.color.rgb.toString;">
     <h2 class="category-item__name">@category.v.name</h2>
     <p class="category-item__slug">@category.v.slug</p>
     <div class="category-item__footer">

--- a/app/views/common/Default.scala.html
+++ b/app/views/common/Default.scala.html
@@ -19,7 +19,7 @@
     @* And here's where we render the `Html` object containing
     * the page content. *@
     <header class="header">
-      <div class="header__content"><span class="header__logo">To-do app</span></div>
+      <div class="header__content"><a class="header__logo" href="@routes.HomeController.index()">To-do app</a></div>
       <link href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" rel="stylesheet">
     </header>
     <main class="main">

--- a/app/views/todo/Edit.scala.html
+++ b/app/views/todo/Edit.scala.html
@@ -15,7 +15,7 @@ Todo更新画面
           <dd class="todo-form__category-dd">
             @* 全てのカテゴリが削除されている場合　専用の文言を表示する *@
             @if(vv.allCategory.isEmpty){
-              <p>ありません</p>
+              ありません
             }
 
             @* 何もボタンが選択されなければ編集前にcategoryIdに格納されていた値が送信される *@

--- a/app/views/todo/Edit.scala.html
+++ b/app/views/todo/Edit.scala.html
@@ -4,18 +4,44 @@ Todo更新画面
 @import model.view.viewvalues.ViewValueTodoEdit
 @(vv: ViewValueTodoEdit)(implicit messageProvider: MessagesProvider,  requestHeader: RequestHeader)
 @common.Default(vv){
-  <div  class="edit-form">
-    @* 追加するTodoの入力フォーム *@
+  <div  class="todo-form">
+    @* 更新するTodoの入力フォーム *@
     @helper.form(action = routes.TodoController.update(vv.todoId)){
       @helper.CSRF.formField
-      <div class="edit-form__category-input">
-        @* カテゴリIdの入力欄(longNumber) *@
-        @helper.inputText(
-          vv.form("categoryId"),
-          '_label -> "カテゴリid", '_showConstraints -> false
-        )
-      </div>
-      <div class="edit-form__title-input">
+      <div class="todo-form__category-input">
+        @* カテゴリのラジオボタン *@
+        <dl>
+          <dt>カテゴリ</dt>
+          <dd class="todo-form__category-dd">
+            @* 全てのカテゴリが削除されている場合　専用の文言を表示する *@
+            @if(vv.allCategory.isEmpty){
+              <p>ありません</p>
+            }
+
+            @* 何もボタンが選択されなければ編集前にcategoryIdに格納されていた値が送信される *@
+            @*
+               何もボタンが選択されない状況:
+　　　　　　　　　1. 全てのカテゴリが削除されており、そもそもラジオボタンが存在しない場合
+               2. 保存されていたcategoryIdに対応するカテゴリがDBに存在しない かつ　ラジオボタンを選択しなかった場合
+            *@
+            <input type="radio" name="categoryId" value="@vv.form("categoryId").value.get.toLong" checked style="display:none;">
+
+            @* 個々のラジオボタンを作成 *@
+            @for(ctg <- vv.allCategory){
+              <input type="radio" id="ctg_@ctg.id.toString" class="todo-form__category-btn" name="categoryId" value=@ctg.id.toString
+                     @if(ctg.id.toLong == vv.form("categoryId").value.get.toLong){checked}>
+              <label for="ctg_@ctg.id.toString" class="todo-form__category-label" style="--color: @ctg.v.color.rgb.toString">@ctg.v.slug</label>
+            }
+          </dd>
+
+          @* エラーがあれば表示する *@
+          @for(error <- vv.form("categoryId").errors){
+            @* helperを用いた入力欄に倣いclassをerrorにする *@
+            <dd class="error">@error.format</dd>
+          }
+        </dl>
+    </div>
+      <div class="todo-form__title-input">
         @* Todoタイトルの入力欄(NonEmptyText) *@
         @helper.inputText(
           vv.form("title"),
@@ -23,7 +49,7 @@ Todo更新画面
           '_label -> "Todoタイトル", '_showConstraints -> false
         )
       </div>
-      <div class="edit-form__body-input">
+      <div class="todo-form__body-input">
         @* Todo本文の入力欄(text) *@
         @helper.textarea(
           vv.form("body"),
@@ -31,7 +57,7 @@ Todo更新画面
           '_label -> "Todo本文", '_showConstraints -> false
         )
       </div>
-      <div class="edit-form__status-raido-btn">
+      <div class="todo-form__status-raido-btn">
         @* Todoステータスのラジオボタン *@
         @helper.inputRadioGroup(
           vv.form("state"),
@@ -39,7 +65,7 @@ Todo更新画面
           '_label -> "ステータス", '_showConstraints -> false
         )
       </div>
-      <input class="edit-form__submit-btn" type="submit" value="更新">
+      <input class="todo-form__submit-btn" type="submit" value="更新">
     }
   </div>
 }

--- a/app/views/todo/List.scala.html
+++ b/app/views/todo/List.scala.html
@@ -9,7 +9,7 @@ Todo一覧を表示するページ
           <h2 class="todo-item__title">@todo.v.title</h2>
           <div class="todo-item__sub-info">
             <p class="todo-item__status">@todo.v.state.name</p>
-            <p class="todo-item__category">@todo.v.categoryId</p>
+            <p class="todo-item__category">@vv.allCategory.find(_.id == todo.v.categoryId).map(_.v.slug)</p>
           </div>
           <p class="todo-item__body">@todo.v.body</p>
           <div class="todo-item__footer">

--- a/app/views/todo/List.scala.html
+++ b/app/views/todo/List.scala.html
@@ -9,7 +9,7 @@ Todo一覧を表示するページ
           <h2 class="todo-item__title">@todo.v.title</h2>
           <div class="todo-item__sub-info">
             <p class="todo-item__status">@todo.v.state.name</p>
-            <p class="todo-item__category" style="--color: @vv.allCategory.find(_.id == todo.v.categoryId).map(_.v.color.toString)">@vv.allCategory.find(_.id == todo.v.categoryId).map(_.v.slug)</p>
+            <p class="todo-item__category" style="--color: @vv.allCategory.find(_.id == todo.v.categoryId).map(_.v.color.rgb.toString)">@vv.allCategory.find(_.id == todo.v.categoryId).map(_.v.slug)</p>
           </div>
           <p class="todo-item__body">@todo.v.body</p>
           <div class="todo-item__footer">

--- a/app/views/todo/List.scala.html
+++ b/app/views/todo/List.scala.html
@@ -9,7 +9,7 @@ Todo一覧を表示するページ
           <h2 class="todo-item__title">@todo.v.title</h2>
           <div class="todo-item__sub-info">
             <p class="todo-item__status">@todo.v.state.name</p>
-            <p class="todo-item__category">@vv.allCategory.find(_.id == todo.v.categoryId).map(_.v.slug)</p>
+            <p class="todo-item__category" style="--color: @vv.allCategory.find(_.id == todo.v.categoryId).map(_.v.color.toString)">@vv.allCategory.find(_.id == todo.v.categoryId).map(_.v.slug)</p>
           </div>
           <p class="todo-item__body">@todo.v.body</p>
           <div class="todo-item__footer">

--- a/app/views/todo/Store.scala.html
+++ b/app/views/todo/Store.scala.html
@@ -19,13 +19,13 @@ Todo追加画面
               <p>ありません</p>
             }
 
-            @* 何もボタンが選択されなければCategory.deletedCategoryIdが送信される *@
+            @* 何もボタンが選択されなければCategory.deletedIdが送信される *@
             @*
                何もボタンが選択されない状況:
 　　　　　　　　　1. 全てのカテゴリが削除されており、そもそもラジオボタンが存在しない場合
                2. ラジオボタンを選択しなかった場合
             *@
-            <input type="radio" name="categoryId" value="@Category.deletedCategoryId" style="display:none;" checked>
+            <input type="radio" name="categoryId" value="@Category.deletedId" style="display:none;" checked>
 
             @* 個々のラジオボタンを作成 *@
             @for(ctg <- vv.allCategory){

--- a/app/views/todo/Store.scala.html
+++ b/app/views/todo/Store.scala.html
@@ -2,20 +2,46 @@
 Todo追加画面
 *@
 @import model.view.viewvalues.ViewValueTodoStore
+@import lib.model.Category
 @(vv: ViewValueTodoStore)(implicit messageProvider: MessagesProvider,  requestHeader: RequestHeader)
 @common.Default(vv){
-  <div  class="store-form">
+  <div  class="todo-form">
     @* 追加するTodoの入力フォーム *@
     @helper.form(action = routes.TodoController.store){
       @helper.CSRF.formField
-      <div class="store-form__category-input">
-        @* カテゴリIdの入力欄(longNumber) *@
-        @helper.inputText(
-          vv.form("categoryId"),
-          '_label -> "カテゴリid", '_showConstraints -> false
-        )
+      <div class="todo-form__category-input">
+        @* カテゴリのラジオボタン *@
+        <dl>
+          <dt>カテゴリ</dt>
+          <dd class="todo-form__category-dd">
+            @* 全てのカテゴリが削除されている場合　専用の文言を表示する *@
+            @if(vv.allCategory.isEmpty){
+              <p>ありません</p>
+            }
+
+            @* 何もボタンが選択されなければCategory.deletedCategoryIdが送信される *@
+            @*
+               何もボタンが選択されない状況:
+　　　　　　　　　1. 全てのカテゴリが削除されており、そもそもラジオボタンが存在しない場合
+               2. ラジオボタンを選択しなかった場合
+            *@
+            <input type="radio" name="categoryId" value="@Category.deletedCategoryId" style="display:none;" checked>
+
+            @* 個々のラジオボタンを作成 *@
+            @for(ctg <- vv.allCategory){
+              <input type="radio" id="ctg_@ctg.id.toString" class="todo-form__category-btn" name="categoryId" value=@ctg.id.toString>
+              <label for="ctg_@ctg.id.toString" class="todo-form__category-label" style="--color: @ctg.v.color.rgb.toString">@ctg.v.slug</label>
+            }
+          </dd>
+
+          @* エラーがあれば表示する *@
+          @for(error <- vv.form("categoryId").errors){
+            @* helperを用いた入力欄に倣いclassをerrorにする *@
+            <dd class="error">@error.format</dd>
+          }
+        </dl>
       </div>
-      <div class="store-form__title-input">
+      <div class="todo-form__title-input">
         @* Todoタイトルの入力欄(NonEmptyText) *@
         @helper.inputText(
           vv.form("title"),
@@ -23,7 +49,7 @@ Todo追加画面
           '_label -> "Todoタイトル", '_showConstraints -> false
         )
       </div>
-      <div class="store-form__body-input">
+      <div class="todo-form__body-input">
         @* Todo本文の入力欄(text) *@
         @helper.textarea(
           vv.form("body"),
@@ -31,7 +57,7 @@ Todo追加画面
           '_label -> "Todo本文", '_showConstraints -> false
         )
       </div>
-      <input class="store-form__submit-btn" type="submit" value="追加">
+      <input class="todo-form__submit-btn" type="submit" value="追加">
     }
   </div>
 }

--- a/app/views/todo/Store.scala.html
+++ b/app/views/todo/Store.scala.html
@@ -16,7 +16,7 @@ Todo追加画面
           <dd class="todo-form__category-dd">
             @* 全てのカテゴリが削除されている場合　専用の文言を表示する *@
             @if(vv.allCategory.isEmpty){
-              <p>ありません</p>
+              ありません
             }
 
             @* 何もボタンが選択されなければCategory.deletedIdが送信される *@


### PR DESCRIPTION
## 変更内容

- todoモデルのcategoryIdの型をCategory.Idに変更 [38ebef7](https://github.com/yasu307/todo-app/pull/9/commits/38ebef7bfd2a97454db3bf2babaffdf9b264bcf7)
- 上記の変更に伴う処理の変更 [38ebef7](https://github.com/yasu307/todo-app/pull/9/commits/38ebef7bfd2a97454db3bf2babaffdf9b264bcf7)
  - todoを表示する画面に遷移する前に、全カテゴリをDBから取得しviewvalueとして渡すように
  - todo-itemに、対応するカテゴリのslugを表示するように
- todo-item__categoryの背景色を対応するカテゴリの色に変更 [706c72c](https://github.com/yasu307/todo-app/pull/9/commits/706c72cf93bb32296547b6ac1806435cbb3cb5a0)
- todo-formのカテゴリ入力欄をDBにあるカテゴリのラジオボタンに変更 [5795fa7](https://github.com/yasu307/todo-app/pull/9/commits/5795fa7acde00a2363ae39292838a382c2513e92)

## 画面変更
### todo一覧画面(変更)
todo/list
変更内容

- todo-item__categoryに対応するカテゴリのslugを表示
- todo-item__categoryの背景色を対応するカテゴリの色に変更

下の画像では上から2つめのtodo-itemは対応するカテゴリがDBに存在しないため、todo-item__categoryが空欄になっています。

<img width="1792" alt="pull9 todo:list" src="https://user-images.githubusercontent.com/29055153/170668194-a8bdce1c-bdb0-4e7b-8618-c36f255400fe.png">

### todo追加画面(変更)
todo/store
変更内容

- カテゴリの入力欄をDBにあるカテゴリのラジオボタンに変更
- ラジオボタンのラベルの背景色をカテゴリの色に変更

<img width="1792" alt="pull9 todo:store" src="https://user-images.githubusercontent.com/29055153/170668509-830e1917-736c-49ee-a274-20206b667bfd.png">

DBにカテゴリが存在しない場合

<img width="1792" alt="pull9 todo:store-no-category" src="https://user-images.githubusercontent.com/29055153/170668751-7d6bd37b-469d-4cfa-874b-1ac3db3fc006.png">

### todo更新画面(変更)
todo/store
変更内容

- カテゴリの入力欄をDBにあるカテゴリのラジオボタンに変更
- 編集元のtodoに設定されているカテゴリがDBに存在する場合は、ラジオボタンの初期選択がそのカテゴリになるように
- ラジオボタンのラベルの背景色をカテゴリの色に変更

<img width="1792" alt="pull9 todo:edit" src="https://user-images.githubusercontent.com/29055153/170668867-5102b0f6-3c3a-4feb-a060-6a1cb82bf7ed.png">

DBにカテゴリが存在しない場合、カテゴリのラジオボタンは追加画面と同様の表示になります。

## 注意点
todoのフォーム(追加、更新どちらも)においてラジオボタンが選択されずにフォームが送信された場合以下の値が設定されます。
追加フォーム : Category.deletedId
更新フォーム : 元から設定されていたcategoryId

"カテゴリが選択されていなければフォーム画面にRedirectし、エラー文を表示する"という方法もあるのですが、カテゴリがDBに存在しない場合はカテゴリを選択することができないためこのような処理にしました。

またカテゴリを選択せずにフォームを送信するという選択肢があるならば、ラジオボタンの選択を解除する機能も本来は必要だと思うのですが、Angularを用いたほうが実装しやすいだろうと考え今回は実装しませんでした。